### PR TITLE
Bump Gradle Wrapper to 8.7 and AGP to 8.5.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,5 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemor
 # org.gradle.parallel=true
 
 android.useAndroidX=true
+
+android.nonFinalResIds=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -8,6 +8,7 @@ repositories {
 }
 
 android {
+    namespace "com.yalantis.ucrop.sample"
     compileSdk 33
     defaultConfig {
         applicationId "com.yalantis.ucrop.sample"
@@ -16,7 +17,7 @@ android {
         versionCode 1
         versionName "1.0"
     }
-    flavorDimensions "default"
+    flavorDimensions = ["default"]
     buildTypes {
         release {
             minifyEnabled false
@@ -30,11 +31,16 @@ android {
     lintOptions {
         abortOnError false
     }
+    buildFeatures {
+        buildConfig = true
+    }
     productFlavors {
         activity {
+            dimension "default"
             buildConfigField("int","RequestMode", "1")
         }
         fragment {
+            dimension "default"
             buildConfigField("int","RequestMode", "2")
         }
     }

--- a/sample/src/main/java/com/yalantis/ucrop/sample/SampleActivity.java
+++ b/sample/src/main/java/com/yalantis/ucrop/sample/SampleActivity.java
@@ -677,13 +677,13 @@ public class SampleActivity extends BaseActivity implements UCropFragmentCallbac
 
     public void setupViews(Bundle args) {
         settingsView.setVisibility(View.GONE);
-        mStatusBarColor = args.getInt(UCrop.Options.EXTRA_STATUS_BAR_COLOR, ContextCompat.getColor(this, R.color.ucrop_color_statusbar));
-        mToolbarColor = args.getInt(UCrop.Options.EXTRA_TOOL_BAR_COLOR, ContextCompat.getColor(this, R.color.ucrop_color_toolbar));
-        mToolbarCancelDrawable = args.getInt(UCrop.Options.EXTRA_UCROP_WIDGET_CANCEL_DRAWABLE, R.drawable.ucrop_ic_cross);
-        mToolbarCropDrawable = args.getInt(UCrop.Options.EXTRA_UCROP_WIDGET_CROP_DRAWABLE, R.drawable.ucrop_ic_done);
-        mToolbarWidgetColor = args.getInt(UCrop.Options.EXTRA_UCROP_WIDGET_COLOR_TOOLBAR, ContextCompat.getColor(this, R.color.ucrop_color_toolbar_widget));
+        mStatusBarColor = args.getInt(UCrop.Options.EXTRA_STATUS_BAR_COLOR, ContextCompat.getColor(this, com.yalantis.ucrop.R.color.ucrop_color_statusbar));
+        mToolbarColor = args.getInt(UCrop.Options.EXTRA_TOOL_BAR_COLOR, ContextCompat.getColor(this, com.yalantis.ucrop.R.color.ucrop_color_toolbar));
+        mToolbarCancelDrawable = args.getInt(UCrop.Options.EXTRA_UCROP_WIDGET_CANCEL_DRAWABLE, com.yalantis.ucrop.R.drawable.ucrop_ic_cross);
+        mToolbarCropDrawable = args.getInt(UCrop.Options.EXTRA_UCROP_WIDGET_CROP_DRAWABLE, com.yalantis.ucrop.R.drawable.ucrop_ic_done);
+        mToolbarWidgetColor = args.getInt(UCrop.Options.EXTRA_UCROP_WIDGET_COLOR_TOOLBAR, ContextCompat.getColor(this, com.yalantis.ucrop.R.color.ucrop_color_toolbar_widget));
         mToolbarTitle = args.getString(UCrop.Options.EXTRA_UCROP_TITLE_TEXT_TOOLBAR);
-        mToolbarTitle = mToolbarTitle != null ? mToolbarTitle : getResources().getString(R.string.ucrop_label_edit_photo);
+        mToolbarTitle = mToolbarTitle != null ? mToolbarTitle : getResources().getString(com.yalantis.ucrop.R.string.ucrop_label_edit_photo);
 
         setupAppBar();
     }
@@ -737,11 +737,11 @@ public class SampleActivity extends BaseActivity implements UCropFragmentCallbac
 
     @Override
     public boolean onCreateOptionsMenu(final Menu menu) {
-        getMenuInflater().inflate(R.menu.ucrop_menu_activity, menu);
+        getMenuInflater().inflate(com.yalantis.ucrop.R.menu.ucrop_menu_activity, menu);
 
         // Change crop & loader menu icons color to match the rest of the UI colors
 
-        MenuItem menuItemLoader = menu.findItem(R.id.menu_loader);
+        MenuItem menuItemLoader = menu.findItem(com.yalantis.ucrop.R.id.menu_loader);
         Drawable menuItemLoaderIcon = menuItemLoader.getIcon();
         if (menuItemLoaderIcon != null) {
             try {
@@ -749,13 +749,13 @@ public class SampleActivity extends BaseActivity implements UCropFragmentCallbac
                 menuItemLoaderIcon.setColorFilter(mToolbarWidgetColor, PorterDuff.Mode.SRC_ATOP);
                 menuItemLoader.setIcon(menuItemLoaderIcon);
             } catch (IllegalStateException e) {
-                Log.i(this.getClass().getName(), String.format("%s - %s", e.getMessage(), getString(R.string.ucrop_mutate_exception_hint)));
+                Log.i(this.getClass().getName(), String.format("%s - %s", e.getMessage(), getString(com.yalantis.ucrop.R.string.ucrop_mutate_exception_hint)));
             }
             ((Animatable) menuItemLoader.getIcon()).start();
         }
 
-        MenuItem menuItemCrop = menu.findItem(R.id.menu_crop);
-        Drawable menuItemCropIcon = ContextCompat.getDrawable(this, mToolbarCropDrawable == 0 ? R.drawable.ucrop_ic_done : mToolbarCropDrawable);
+        MenuItem menuItemCrop = menu.findItem(com.yalantis.ucrop.R.id.menu_crop);
+        Drawable menuItemCropIcon = ContextCompat.getDrawable(this, mToolbarCropDrawable == 0 ? com.yalantis.ucrop.R.drawable.ucrop_ic_done : mToolbarCropDrawable);
         if (menuItemCropIcon != null) {
             menuItemCropIcon.mutate();
             menuItemCropIcon.setColorFilter(mToolbarWidgetColor, PorterDuff.Mode.SRC_ATOP);
@@ -767,14 +767,14 @@ public class SampleActivity extends BaseActivity implements UCropFragmentCallbac
 
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
-        menu.findItem(R.id.menu_crop).setVisible(!mShowLoader);
-        menu.findItem(R.id.menu_loader).setVisible(mShowLoader);
+        menu.findItem(com.yalantis.ucrop.R.id.menu_crop).setVisible(!mShowLoader);
+        menu.findItem(com.yalantis.ucrop.R.id.menu_loader).setVisible(mShowLoader);
         return super.onPrepareOptionsMenu(menu);
     }
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        if (item.getItemId() == R.id.menu_crop) {
+        if (item.getItemId() == com.yalantis.ucrop.R.id.menu_crop) {
             if (fragment != null && fragment.isAdded())
                 fragment.cropAndSaveImage();
         } else if (item.getItemId() == android.R.id.home) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 pluginManagement {
-    gradle.ext.agpVersion = '7.4.2'
+    gradle.ext.agpVersion = '8.5.1'
     gradle.ext.automatticPublishToS3Version = '0.10.0'
     plugins {
         id "com.android.application" version gradle.ext.agpVersion

--- a/ucrop/build.gradle
+++ b/ucrop/build.gradle
@@ -9,6 +9,7 @@ repositories {
 }
 
 android {
+    namespace "com.yalantis.ucrop"
     compileSdk 33
     defaultConfig {
         minSdkVersion 14
@@ -28,6 +29,9 @@ android {
     }
     lintOptions {
         abortOnError false
+    }
+    buildFeatures {
+        buildConfig = true
     }
 
     resourcePrefix 'ucrop_'


### PR DESCRIPTION


## Description:

There's an [issue on Android 15](https://github.com/Yalantis/uCrop/issues/913). UCrop doesn't work well with the enforcement of the edge-to-edge. 

In order to test this using the sample app I need to bump Gradle and AGP. This is what this PR does.

-----

## Test Instructions:

Build the sample app. A successful build should be enough - the sample app doesn't really work well so don't test it (I will fix it in a separate PR).
